### PR TITLE
Fix pagination

### DIFF
--- a/src/components/pagination.js
+++ b/src/components/pagination.js
@@ -1,6 +1,8 @@
 import React from 'react'
 import Link from './IntlLink'
 
+const toPathLink = (page) => (page === 1 ? '' : `/${page}`)
+
 const Pagination = ({ pathPrefix, currentPage, numPages }) => (
   <nav
     className="pagination PingCAP-Pagination"
@@ -17,7 +19,7 @@ const Pagination = ({ pathPrefix, currentPage, numPages }) => (
         .map((i) => (
           <li key={i}>
             <Link
-              to={`${pathPrefix}${i === 1 ? '' : '/' + i}`}
+              to={`${pathPrefix}${toPathLink(i)}`}
               className={`pagination-link${
                 currentPage === i ? ' is-current' : ''
               }`}
@@ -34,7 +36,7 @@ const Pagination = ({ pathPrefix, currentPage, numPages }) => (
       )}
       <li>
         <Link
-          to={`${pathPrefix}/${numPages}`}
+          to={`${pathPrefix}${toPathLink(numPages)}`}
           className={`pagination-link${
             currentPage === numPages ? ' is-current' : ''
           }`}
@@ -46,7 +48,7 @@ const Pagination = ({ pathPrefix, currentPage, numPages }) => (
       {currentPage !== numPages && (
         <li>
           <Link
-            to={`${pathPrefix}/${currentPage + 1}`}
+            to={`${pathPrefix}${toPathLink(currentPage + 1)}`}
             className="pagination-link"
             aria-label="Go to next page"
           >


### PR DESCRIPTION
When there's only 1 page (like some small categories), the link to page 1 (which is the only page) would be `/<prefix>/1`, resulting in a 404.
