### PR TITLE
chore: hide zh pages from sitemap

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -135,7 +135,7 @@ module.exports = {
       resolve: `gatsby-plugin-sitemap`,
       options: {
         output: `/website-en-sitemap.xml`,
-        exclude: ['/404'],
+        exclude: ['/404', `/zh/*`],
         sitemapSize: 500,
       },
     },


### PR DESCRIPTION
zh pages will be exposed to browser crawlers once Chinese website go live