### PR TITLE
add temp entry for TiDB monthly in en website

### DIFF
--- a/src/data/footer.js
+++ b/src/data/footer.js
@@ -81,6 +81,11 @@ const footerColumns = [
           link: 'https://github.com/pingcap',
           outbound: true,
         },
+        {
+          name: 'TiDB Monthly',
+          link: 'https://pingcap.com/weekly/',
+          outbound: true,
+        },
       ],
     },
   ],


### PR DESCRIPTION
Before we shut down the old access url, we need a temporary entry for TiDB monthly which is still being updated. So this PR adds an entry in the footer, which we can replace or update when we need for next step. @lilin90 FYI