### PR TITLE
chore: remove careers from pingcap sitemap

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -5,7 +5,8 @@ const { createProxyMiddleware } = require('http-proxy-middleware')
 const getSitemapForLanguage = (lang) => {
   const langPrefix = lang === 'en' ? '' : '/zh'
   const _ouput = `/sitemap-${lang}.xml`
-  const _exclude = [`${langPrefix}/404`]
+  const _exclude =
+    lang === 'en' ? [`${langPrefix}/404`, '/careers/*'] : [`${langPrefix}/404`]
   const filterRegex = lang === 'en' ? '/^((?!/zh/).)*$/' : '/^/zh//'
 
   const _query = `{


### PR DESCRIPTION
Since we are using Lever API to fetch English positions instead of generating career pages with markdown pages, so remove the `/careers/*` paths from website sitemap.