### PR TITLE
chore: remove sitemap-zh.xml from sitemap until Chinese pages go live

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -194,16 +194,22 @@ module.exports = {
       },
     },
     `gatsby-plugin-meta-redirect`,
-    ...Object.keys(langConfig.languages).map((lang) => ({
+
+    // stop generating /zh pages from sitemap until Chinese pages go live
+    // ...Object.keys(langConfig.languages).map((lang) => ({
+    //   resolve: `gatsby-plugin-sitemap`,
+    //   options: getSitemapForLanguage(lang),
+    // })),
+    {
       resolve: `gatsby-plugin-sitemap`,
-      options: getSitemapForLanguage(lang),
-    })),
+      options: getSitemapForLanguage('en'),
+    },
     {
       resolve: `gatsby-plugin-sitemap`,
       options: {
         output: '/sitemap.xml',
         serialize: () =>
-          Object.keys(langConfig.languages).map((lang) => ({
+          ['en'].map((lang) => ({
             priority: 1,
             url: `https://pingcap.com/sitemap-${lang}.xml`,
           })),


### PR DESCRIPTION
We are not ready to make Chinese pages go live, so remove sitemap-zh from sitemap temporary. PTAL